### PR TITLE
fix docker internal networking

### DIFF
--- a/services/mqtt-broker/docker-compose.yml
+++ b/services/mqtt-broker/docker-compose.yml
@@ -8,12 +8,6 @@ services:
             context: .
             dockerfile: Dockerfile
         container_name: potpourri-mqtt-broker
-        networks:
-            - potpourri
         ports:
             - ${mqtt_broker_port}:1883
         restart: always
-
-networks:
-    potpourri:
-        driver: bridge

--- a/services/mqtt-broker/docker-compose.yml
+++ b/services/mqtt-broker/docker-compose.yml
@@ -8,6 +8,12 @@ services:
             context: .
             dockerfile: Dockerfile
         container_name: potpourri-mqtt-broker
+        networks:
+            - potpourri
         ports:
             - ${mqtt_broker_port}:1883
         restart: always
+
+networks:
+    potpourri:
+        driver: bridge

--- a/services/persistence/docker-compose.yml
+++ b/services/persistence/docker-compose.yml
@@ -8,8 +8,6 @@ services:
         container_name: potpourri-persistence-influxdb
         volumes:
             - influxdb:/var/lib/influxdb
-        networks:
-            - potpourri
         ports:
             - ${influxdb_port}:8086
         restart: always
@@ -21,15 +19,9 @@ services:
         container_name: potpourri-persistence-telegraf
         volumes:
             - ./telegraf/telegraf.conf:/etc/telegraf/telegraf.conf:ro
-        networks:
-            - potpourri
         depends_on:
             - influxdb
         restart: always
 
 volumes:
     influxdb:
-
-networks:
-    potpourri:
-        driver: bridge

--- a/services/persistence/docker-compose.yml
+++ b/services/persistence/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         volumes:
             - influxdb:/var/lib/influxdb
         networks:
-            - potpourri-mqtt-broker_default
+            - potpourri
         ports:
             - ${influxdb_port}:8086
         restart: always
@@ -22,7 +22,7 @@ services:
         volumes:
             - ./telegraf/telegraf.conf:/etc/telegraf/telegraf.conf:ro
         networks:
-            - potpourri-mqtt-broker_default
+            - potpourri
         depends_on:
             - influxdb
         restart: always
@@ -31,5 +31,5 @@ volumes:
     influxdb:
 
 networks:
-    potpourri-mqtt-broker_default:
-        external: true
+    potpourri:
+        driver: bridge

--- a/services/persistence/docker-compose.yml
+++ b/services/persistence/docker-compose.yml
@@ -32,5 +32,7 @@ volumes:
     influxdb:
 
 networks:
+    potpourri-persistence_default:
+        driver: bridge
     potpourri-mqtt-broker_default:
         external: true

--- a/services/persistence/docker-compose.yml
+++ b/services/persistence/docker-compose.yml
@@ -8,6 +8,8 @@ services:
         container_name: potpourri-persistence-influxdb
         volumes:
             - influxdb:/var/lib/influxdb
+        networks:
+            - potpourri-mqtt-broker_default
         ports:
             - ${influxdb_port}:8086
         restart: always
@@ -19,9 +21,15 @@ services:
         container_name: potpourri-persistence-telegraf
         volumes:
             - ./telegraf/telegraf.conf:/etc/telegraf/telegraf.conf:ro
+        networks:
+            - potpourri-mqtt-broker_default
         depends_on:
             - influxdb
         restart: always
 
 volumes:
     influxdb:
+
+networks:
+    potpourri-mqtt-broker_default:
+        external: true

--- a/services/persistence/docker-compose.yml
+++ b/services/persistence/docker-compose.yml
@@ -8,6 +8,8 @@ services:
         container_name: potpourri-persistence-influxdb
         volumes:
             - influxdb:/var/lib/influxdb
+        networks:
+            - potpourri-persistence_default
         ports:
             - ${influxdb_port}:8086
         restart: always
@@ -20,6 +22,7 @@ services:
         volumes:
             - ./telegraf/telegraf.conf:/etc/telegraf/telegraf.conf:ro
         networks:
+            - potpourri-persistence_default
             - potpourri-mqtt-broker_default
         depends_on:
             - influxdb

--- a/services/persistence/docker-compose.yml
+++ b/services/persistence/docker-compose.yml
@@ -19,9 +19,15 @@ services:
         container_name: potpourri-persistence-telegraf
         volumes:
             - ./telegraf/telegraf.conf:/etc/telegraf/telegraf.conf:ro
+        networks:
+            - potpourri-mqtt-broker_default
         depends_on:
             - influxdb
         restart: always
 
 volumes:
     influxdb:
+
+networks:
+    potpourri-mqtt-broker_default:
+        external: true

--- a/services/persistence/docker-compose.yml
+++ b/services/persistence/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         volumes:
             - influxdb:/var/lib/influxdb
         networks:
-            - potpourri-persistence_default
+            - default
         ports:
             - ${influxdb_port}:8086
         restart: always
@@ -22,7 +22,7 @@ services:
         volumes:
             - ./telegraf/telegraf.conf:/etc/telegraf/telegraf.conf:ro
         networks:
-            - potpourri-persistence_default
+            - default
             - potpourri-mqtt-broker_default
         depends_on:
             - influxdb
@@ -32,7 +32,7 @@ volumes:
     influxdb:
 
 networks:
-    potpourri-persistence_default:
+    default:
         driver: bridge
     potpourri-mqtt-broker_default:
         external: true

--- a/services/persistence/telegraf/telegraf.conf
+++ b/services/persistence/telegraf/telegraf.conf
@@ -5895,7 +5895,7 @@
 
 # MQTT topis with integer values as string:
 [[inputs.mqtt_consumer]]
-  servers = ["tcp://serenity:1883"]
+  servers = ["tcp://localhost:1883"]
   topics = [
      "potpourri/devices/+/sensors/humidity"
   ]

--- a/services/persistence/telegraf/telegraf.conf
+++ b/services/persistence/telegraf/telegraf.conf
@@ -5832,7 +5832,7 @@
 #[[inputs.mqtt_consumer]]
 #   ## MQTT broker URLs to be used. The format should be scheme://host:port,
 #   ## schema can be tcp, ssl, or ws.
-#  servers = ["tcp://serenity:1883"]
+#  servers = ["tcp://potpourri-mqtt-broker:1883"]
 #
 #   ## Topics that will be subscribed to.
 #  topics = [

--- a/services/persistence/telegraf/telegraf.conf
+++ b/services/persistence/telegraf/telegraf.conf
@@ -5895,7 +5895,7 @@
 
 # MQTT topis with integer values as string:
 [[inputs.mqtt_consumer]]
-  servers = ["tcp://localhost:1883"]
+  servers = ["tcp://potpourri-mqtt-broker:1883"]
   topics = [
      "potpourri/devices/+/sensors/humidity"
   ]

--- a/services/visualization/docker-compose.yml
+++ b/services/visualization/docker-compose.yml
@@ -11,7 +11,7 @@ services:
             - ./grafana/grafana.ini:/etc/grafana/grafana.ini:ro
             - ./grafana/provisioning:/etc/grafana/provisioning:ro
         networks:
-            - potpourri
+            - potpourri-persistence_default
         ports:
             - ${grafana_port}:3000
         restart: always
@@ -20,5 +20,5 @@ volumes:
     grafana:
 
 networks:
-    potpourri:
-        driver: bridge
+    potpourri-persistence_default:
+        external: true

--- a/services/visualization/docker-compose.yml
+++ b/services/visualization/docker-compose.yml
@@ -10,6 +10,8 @@ services:
             - grafana:/var/lib/grafana
             - ./grafana/grafana.ini:/etc/grafana/grafana.ini:ro
             - ./grafana/provisioning:/etc/grafana/provisioning:ro
+        networks:
+            - potpourri
         ports:
             - ${grafana_port}:3000
         networks:
@@ -20,5 +22,5 @@ volumes:
     grafana:
 
 networks:
-    potpourri-persistence_default:
-        external: true
+    potpourri:
+        driver: bridge

--- a/services/visualization/docker-compose.yml
+++ b/services/visualization/docker-compose.yml
@@ -14,8 +14,6 @@ services:
             - potpourri
         ports:
             - ${grafana_port}:3000
-        networks:
-            - potpourri-persistence_default
         restart: always
 
 volumes:


### PR DESCRIPTION
Telegraf can now connect to the mqtt broker directly via docker internal networking and doesn't require the public hostname of the host anymore.